### PR TITLE
Unit Tests for Web

### DIFF
--- a/CSharpTradeOffers/CSharpTradeOffers.csproj
+++ b/CSharpTradeOffers/CSharpTradeOffers.csproj
@@ -75,12 +75,14 @@
     <Compile Include="Configuration\XmlConfigHandler.cs" />
     <Compile Include="IRequestHandler.cs" />
     <Compile Include="IResponse.cs" />
+    <Compile Include="ISteamStream.cs" />
     <Compile Include="Json\LoginResult.cs" />
     <Compile Include="Json\RsaKey.cs" />
     <Compile Include="Json\TransferParameters.cs" />
     <Compile Include="RsaHelper.cs" />
     <Compile Include="SteamRequestHandler.cs" />
     <Compile Include="SteamResponse.cs" />
+    <Compile Include="SteamStream.cs" />
     <Compile Include="Trading\Data Classes\Action.cs" />
     <Compile Include="Trading\Data Classes\AppData.cs" />
     <Compile Include="Trading\Data Classes\AssetClassInfo.cs" />

--- a/CSharpTradeOffers/CSharpTradeOffers.csproj
+++ b/CSharpTradeOffers/CSharpTradeOffers.csproj
@@ -73,6 +73,14 @@
     <Compile Include="Configuration\Data Classes\Officer.cs" />
     <Compile Include="Configuration\Data Classes\Config.cs" />
     <Compile Include="Configuration\XmlConfigHandler.cs" />
+    <Compile Include="IRequestHandler.cs" />
+    <Compile Include="IResponse.cs" />
+    <Compile Include="Json\LoginResult.cs" />
+    <Compile Include="Json\RsaKey.cs" />
+    <Compile Include="Json\TransferParameters.cs" />
+    <Compile Include="RsaHelper.cs" />
+    <Compile Include="SteamRequestHandler.cs" />
+    <Compile Include="SteamResponse.cs" />
     <Compile Include="Trading\Data Classes\Action.cs" />
     <Compile Include="Trading\Data Classes\AppData.cs" />
     <Compile Include="Trading\Data Classes\AssetClassInfo.cs" />

--- a/CSharpTradeOffers/Community/CommunityHandler.cs
+++ b/CSharpTradeOffers/Community/CommunityHandler.cs
@@ -13,6 +13,8 @@ namespace CSharpTradeOffers.Community
     /// </summary>
     public class CommunityHandler
     {
+        private readonly Web _web = new Web(new SteamRequestHandler());
+
         /// <summary>
         /// Posts a comment to the specified profile.
         /// </summary>
@@ -35,7 +37,7 @@ namespace CSharpTradeOffers.Community
             };
 
             return
-                JsonConvert.DeserializeObject<CommentResponse>(Web.Fetch(url, "POST", data, authContainer, true,
+                JsonConvert.DeserializeObject<CommentResponse>(_web.Fetch(url, "POST", data, authContainer, true,
                     url.Substring(0, url.Length - 3)));
         }
 
@@ -64,7 +66,7 @@ namespace CSharpTradeOffers.Community
                 {"sessionid", sessionid}
             };
 
-            return JsonConvert.DeserializeObject<ClanCommentResponse>(Web.Fetch(url, "POST", data, authContainer));
+            return JsonConvert.DeserializeObject<ClanCommentResponse>(_web.Fetch(url, "POST", data, authContainer));
         }
 
         /// <summary>
@@ -88,7 +90,7 @@ namespace CSharpTradeOffers.Community
                 {"accept_invite", "0"}
             };
 
-            return JsonConvert.DeserializeObject<AddFriendResponse>(Web.Fetch(url, "POST", data, authContainer));
+            return JsonConvert.DeserializeObject<AddFriendResponse>(_web.Fetch(url, "POST", data, authContainer));
         }
 
         /// <summary>
@@ -112,7 +114,7 @@ namespace CSharpTradeOffers.Community
                 {"accept_invite","1" }
             };
 
-            return Convert.ToBoolean(Web.Fetch(url, "POST", data, authContainer));
+            return Convert.ToBoolean(_web.Fetch(url, "POST", data, authContainer));
         }
 
         /// <summary>
@@ -135,7 +137,7 @@ namespace CSharpTradeOffers.Community
                 {"steamid", steamId.ToString()},
             };
 
-            return Convert.ToBoolean(Web.Fetch(url, "POST", data, authContainer));
+            return Convert.ToBoolean(_web.Fetch(url, "POST", data, authContainer));
         }
 
         /// <summary>
@@ -161,7 +163,7 @@ namespace CSharpTradeOffers.Community
                 {"sessionID", sessionid},
                 {"invitee", steamId.ToString()}
             };
-            return JsonConvert.DeserializeObject<InviteResponse>(Web.Fetch(url, "POST", data, authContainer));
+            return JsonConvert.DeserializeObject<InviteResponse>(_web.Fetch(url, "POST", data, authContainer));
         }
 
         /// <summary>
@@ -187,7 +189,7 @@ namespace CSharpTradeOffers.Community
                 {"sessionID", sessionid},
                 {"invitee_list", ToJArray(steamIds)}
             };
-            return JsonConvert.DeserializeObject<MultiInviteResponse>(Web.Fetch(url, "POST", data, authContainer));
+            return JsonConvert.DeserializeObject<MultiInviteResponse>(_web.Fetch(url, "POST", data, authContainer));
         }
 
         /// <summary>
@@ -215,7 +217,7 @@ namespace CSharpTradeOffers.Community
 
             return
                 (MemberList)
-                    new XmlSerializer(typeof (MemberList)).Deserialize(Web.FetchStream(string.Format(url, groupId),
+                    new XmlSerializer(typeof (MemberList)).Deserialize(_web.FetchStream(string.Format(url, groupId),
                         "GET"));
         }
 
@@ -230,7 +232,7 @@ namespace CSharpTradeOffers.Community
 
             return
                 (MemberList)
-                    new XmlSerializer(typeof (MemberList)).Deserialize(Web.FetchStream(string.Format(url, groupName),
+                    new XmlSerializer(typeof (MemberList)).Deserialize(_web.FetchStream(string.Format(url, groupName),
                         "GET"));
         }
 
@@ -257,7 +259,7 @@ namespace CSharpTradeOffers.Community
                 try
                 {
                     var populatedList = (MemberList)
-                        (new XmlSerializer(typeof (MemberList)).Deserialize(Web.RetryFetchStream(retryWait, retryCount,
+                        (new XmlSerializer(typeof (MemberList)).Deserialize(_web.RetryFetchStream(retryWait, retryCount,
                             temp, "GET")));
                     membersList.Add(populatedList);
                     if (!firstRequest)
@@ -305,7 +307,7 @@ namespace CSharpTradeOffers.Community
                 try
                 {
                     var populatedList = (MemberList)
-                        (new XmlSerializer(typeof (MemberList)).Deserialize(Web.RetryFetchStream(retryWait, retryCount,
+                        (new XmlSerializer(typeof (MemberList)).Deserialize(_web.RetryFetchStream(retryWait, retryCount,
                             temp, "GET")));
                     membersList.Add(populatedList);
 
@@ -369,7 +371,7 @@ namespace CSharpTradeOffers.Community
                 {"primary_group_steamid", profile.PrimaryGroupSteamId.ToString()}
             };
 
-            string response = Web.Fetch(url, "POST", data, account.AuthContainer);
+            string response = _web.Fetch(url, "POST", data, account.AuthContainer);
             return response.Contains("<div class=\"saved_changes_msg\">");
         }
 
@@ -399,7 +401,7 @@ namespace CSharpTradeOffers.Community
                 {"tradeConfirmationSetting", settings.TradeConfirmationSetting.IntValue().ToString()},
                 {"marketConfirmationSetting", settings.MarketConfirmationSetting.IntValue().ToString()}
             };
-            Web.Fetch(url, "POST", data, account.AuthContainer);
+            _web.Fetch(url, "POST", data, account.AuthContainer);
         }
     }
 }

--- a/CSharpTradeOffers/Community/CommunityHandler.cs
+++ b/CSharpTradeOffers/Community/CommunityHandler.cs
@@ -14,7 +14,7 @@ namespace CSharpTradeOffers.Community
     public class CommunityHandler
     {
         private readonly Web _web = new Web(new SteamRequestHandler());
-
+        private static TimeSpan defaultRetryRate = new TimeSpan(0,0,0,1000); 
         /// <summary>
         /// Posts a comment to the specified profile.
         /// </summary>
@@ -218,7 +218,7 @@ namespace CSharpTradeOffers.Community
             return
                 (MemberList)
                     new XmlSerializer(typeof (MemberList)).Deserialize(_web.FetchStream(string.Format(url, groupId),
-                        "GET"));
+                        "GET").GetUnderlyingStream());
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace CSharpTradeOffers.Community
             return
                 (MemberList)
                     new XmlSerializer(typeof (MemberList)).Deserialize(_web.FetchStream(string.Format(url, groupName),
-                        "GET"));
+                        "GET").GetUnderlyingStream());
         }
 
         /// <summary>
@@ -243,7 +243,7 @@ namespace CSharpTradeOffers.Community
         /// <param name="retryWait">The number of miliseconds to wait between each retry.</param>
         /// <param name="retryCount">The number of times to retry before inserting a null MemberList object.</param>
         /// <returns>A List of the MemberList object.</returns>
-        public List<MemberList> RequestAllMemberLists(ulong groupId, int retryWait = 1000, int retryCount = 10)
+        public List<MemberList> RequestAllMemberLists(ulong groupId, TimeSpan retryWait, int retryCount = 10)
         {
             var membersList = new List<MemberList>();
             const string url = "http://steamcommunity.com/gid/{0}/memberslistxml/?xml=1&p={1}";
@@ -260,7 +260,7 @@ namespace CSharpTradeOffers.Community
                 {
                     var populatedList = (MemberList)
                         (new XmlSerializer(typeof (MemberList)).Deserialize(_web.RetryFetchStream(retryWait, retryCount,
-                            temp, "GET")));
+                            temp, "GET").GetUnderlyingStream()));
                     membersList.Add(populatedList);
                     if (!firstRequest)
                     {
@@ -291,7 +291,7 @@ namespace CSharpTradeOffers.Community
         /// <param name="retryWait">The number of miliseconds to wait between each retry.</param>
         /// <param name="retryCount">The number of times to retry before inserting a null MemberList object.</param>
         /// <returns>A List of the MemberList object.</returns>
-        public List<MemberList> RequestAllMemberLists(string groupName, int retryWait = 1000, int retryCount = 10)
+        public List<MemberList> RequestAllMemberLists(string groupName, TimeSpan retryWait, int retryCount = 10)
         {
             var membersList = new List<MemberList>();
             groupName = groupName.Replace(" ", "");
@@ -308,7 +308,7 @@ namespace CSharpTradeOffers.Community
                 {
                     var populatedList = (MemberList)
                         (new XmlSerializer(typeof (MemberList)).Deserialize(_web.RetryFetchStream(retryWait, retryCount,
-                            temp, "GET")));
+                            temp, "GET").GetUnderlyingStream()));
                     membersList.Add(populatedList);
 
                     if (!firstRequest)

--- a/CSharpTradeOffers/Community/SteamUserHandler.cs
+++ b/CSharpTradeOffers/Community/SteamUserHandler.cs
@@ -12,6 +12,8 @@ namespace CSharpTradeOffers.Community
         private const string BaseUrl = "http://api.steampowered.com/ISteamUser/";
         private readonly string _apiKey;
 
+        private readonly Web _web = new Web(new SteamRequestHandler());
+
         public SteamUserHandler(string apiKey)
         {
             _apiKey = apiKey;
@@ -35,7 +37,7 @@ namespace CSharpTradeOffers.Community
                 {"relationship", relationship}
             };
             return
-                JsonConvert.DeserializeObject<GetFriendListResult>(Web.Fetch(url, "GET", data, null, false))
+                JsonConvert.DeserializeObject<GetFriendListResult>(_web.Fetch(url, "GET", data, null, false))
                     .Friendslist.Friends;
         }
 
@@ -53,7 +55,7 @@ namespace CSharpTradeOffers.Community
                 {"steamids", CommaDelimit(playersBansToRequest)}
             };
             return
-                JsonConvert.DeserializeObject<GetPlayerBansResult>(Web.Fetch(url, "GET", data, null, false)).PlayerBans;
+                JsonConvert.DeserializeObject<GetPlayerBansResult>(_web.Fetch(url, "GET", data, null, false)).PlayerBans;
         }
 
         /// <summary>
@@ -70,7 +72,7 @@ namespace CSharpTradeOffers.Community
                 {"steamids", CommaDelimit(playerSummariesToRequest)}
             };
             return
-                JsonConvert.DeserializeObject<GetPlayerSummariesV2Result>(Web.Fetch(url, "GET", data, null, false))
+                JsonConvert.DeserializeObject<GetPlayerSummariesV2Result>(_web.Fetch(url, "GET", data, null, false))
                     .Response.PlayersSummaries;
         }
 
@@ -88,7 +90,7 @@ namespace CSharpTradeOffers.Community
                 {"steamid", steamId.ToString()}
             };
             return
-                JsonConvert.DeserializeObject<GetUserGroupListBaseResult>(Web.Fetch(url, "GET", data, null, false))
+                JsonConvert.DeserializeObject<GetUserGroupListBaseResult>(_web.Fetch(url, "GET", data, null, false))
                     .Result;
         }
 
@@ -112,7 +114,7 @@ namespace CSharpTradeOffers.Community
                 {"url_type", urlType.ToString()}
             };
             return
-                JsonConvert.DeserializeObject<ResolveVanityUrlBaseResult>(Web.Fetch(url, "GET", data, null, false))
+                JsonConvert.DeserializeObject<ResolveVanityUrlBaseResult>(_web.Fetch(url, "GET", data, null, false))
                     .Response;
         }
 

--- a/CSharpTradeOffers/IRequestHandler.cs
+++ b/CSharpTradeOffers/IRequestHandler.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace CSharpTradeOffers
+{
+    public interface IRequestHandler<out TResponse> where TResponse : IResponse
+    {
+        TResponse HandleRequest(string url, string method, Dictionary<string, string> data,
+            CookieContainer cookies, bool xHeaders, string referer);
+    }
+}

--- a/CSharpTradeOffers/IResponse.cs
+++ b/CSharpTradeOffers/IResponse.cs
@@ -1,0 +1,12 @@
+using System;
+using System.IO;
+using System.Net;
+
+namespace CSharpTradeOffers
+{
+    public interface IResponse : IDisposable
+    {
+        Stream GetResponseStream();
+        CookieCollection Cookies { get; }
+    }
+}

--- a/CSharpTradeOffers/IResponse.cs
+++ b/CSharpTradeOffers/IResponse.cs
@@ -1,12 +1,11 @@
 using System;
-using System.IO;
 using System.Net;
 
 namespace CSharpTradeOffers
 {
     public interface IResponse : IDisposable
     {
-        Stream GetResponseStream();
+        ISteamStream GetResponseStream();
         CookieCollection Cookies { get; }
     }
 }

--- a/CSharpTradeOffers/ISteamStream.cs
+++ b/CSharpTradeOffers/ISteamStream.cs
@@ -1,0 +1,10 @@
+using System.IO;
+
+namespace CSharpTradeOffers
+{
+    public interface ISteamStream
+    {
+        string ReadToEnd();
+        Stream GetUnderlyingStream();
+    }
+}

--- a/CSharpTradeOffers/Json/LoginResult.cs
+++ b/CSharpTradeOffers/Json/LoginResult.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace CSharpTradeOffers.Json
+{
+    [JsonObject(Title = "RootObject")]
+    public class LoginResult
+    {
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+        [JsonProperty("requires_twofactor")]
+        public bool RequiresTwofactor { get; set; }
+        [JsonProperty("message")]
+        public string Message { get; set; }
+        [JsonProperty("captcha_needed")]
+        public bool CaptchaNeeded { get; set; }
+        [JsonProperty("captcha_gid")]
+        public string CaptchaGid { get; set; }
+        [JsonProperty("emailauth_needed")]
+        public bool EmailAuthNeeded { get; set; }
+        [JsonProperty("emaildomain")]
+        public string EmailDomain { get; set; }
+        [JsonProperty("emailsteamid")]
+        public string EmailSteamId { get; set; }
+        [JsonProperty("login_complete")]
+        public bool LoginComplete { get; set; }
+        [JsonProperty("transfer_url")]
+        public string TransferUrl { get; set; }
+        [JsonProperty("transfer_parameters")]
+        public TransferParameters TransferParameters { get; set; }
+    }
+}

--- a/CSharpTradeOffers/Json/RsaKey.cs
+++ b/CSharpTradeOffers/Json/RsaKey.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace CSharpTradeOffers.Json
+{
+    public class RsaKey
+    {
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+        [JsonProperty("publickey_mod")]
+        public string PublicKeyMod { get; set; }
+        [JsonProperty("publickey_exp")]
+        public string PublicKeyExp { get; set; }
+        [JsonProperty("timestamp")]
+        public string TimeStamp { get; set; }
+    }
+
+}

--- a/CSharpTradeOffers/Json/TransferParameters.cs
+++ b/CSharpTradeOffers/Json/TransferParameters.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace CSharpTradeOffers.Json
+{
+    [JsonObject(Title = "Transfer_Parameters")]
+    public class TransferParameters
+    {
+        [JsonProperty("steamid")]
+        public string Steamid { get; set; }
+        [JsonProperty("token")]
+        public string Token { get; set; }
+        [JsonProperty("auth")]
+        public string Auth { get; set; }
+        [JsonProperty("remember_login")]
+        public bool RememberLogin { get; set; }
+        [JsonProperty("token_secure")]
+        public string TokenSecure { get; set; }
+    }
+}

--- a/CSharpTradeOffers/MarketHandler.cs
+++ b/CSharpTradeOffers/MarketHandler.cs
@@ -10,8 +10,10 @@ namespace CSharpTradeOffers
     /// </summary>
     public class MarketHandler
     {
-        const string BaseUrl = "https://steamcommunity.com/market/";
-        
+        private const string BaseUrl = "https://steamcommunity.com/market/";
+
+        private readonly Web _web = new Web(new SteamRequestHandler());
+
         /// <summary>
         /// Sets the container to contain a MarketEligibility cookie. Required before trading.
         /// </summary>
@@ -20,8 +22,8 @@ namespace CSharpTradeOffers
         public void EligibilityCheck(ulong steamId, CookieContainer container)
         {
             const string url = BaseUrl + "eligibilitycheck/";
-            var data = new Dictionary<string, string> { { "goto", "/profiles/" + steamId + "/tradeoffers/" } };
-            Web.Fetch(url, "GET", data, container, false);
+            var data = new Dictionary<string, string> {{"goto", "/profiles/" + steamId + "/tradeoffers/"}};
+            _web.Fetch(url, "GET", data, container, false);
         }
 
         /// <summary>
@@ -42,7 +44,7 @@ namespace CSharpTradeOffers
                 {"appid", appId.ToString()},
                 {"market_hash_name", marketHashName}
             };
-            return JsonConvert.DeserializeObject<MarketValue>(Web.Fetch(url, "GET", data, null, false));
+            return JsonConvert.DeserializeObject<MarketValue>(_web.Fetch(url, "GET", data, null, false));
         }
     }
 }

--- a/CSharpTradeOffers/RsaHelper.cs
+++ b/CSharpTradeOffers/RsaHelper.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+using CSharpTradeOffers.Json;
+using Newtonsoft.Json;
+
+namespace CSharpTradeOffers
+{
+    public class RsaHelper
+    {
+        private readonly string _password;
+
+        public RsaHelper(string password)
+        {
+            _password = password;
+        }
+
+        public string EncryptPasswordResponse(string response)
+        {
+            if (!RequestRsaKey(response)) return null;
+
+            //RSA Encryption
+            var rsa = new RSACryptoServiceProvider();
+            var rsaParameters = new RSAParameters
+            {
+                Exponent = HexToByte(RsaJson.PublicKeyExp),
+                Modulus = HexToByte(RsaJson.PublicKeyMod)
+            };
+
+            rsa.ImportParameters(rsaParameters);
+
+            byte[] bytePassword = Encoding.ASCII.GetBytes(_password);
+            byte[] encodedPassword = rsa.Encrypt(bytePassword, false);
+            return Convert.ToBase64String(encodedPassword);
+        }
+
+        private bool RequestRsaKey(string response)
+        {
+            RsaKey rsaJson = JsonConvert.DeserializeObject<RsaKey>(response);
+            if (!rsaJson.Success) return false;
+            RsaJson = rsaJson;
+            return true;
+        }
+
+
+        private static byte[] HexToByte(string hex)
+        {
+            if (hex.Length%2 == 1)
+                throw new Exception("The binary key cannot have an odd number of digits");
+
+            byte[] arr = new byte[hex.Length >> 1];
+            int l = hex.Length;
+
+            for (int i = 0; i < (l >> 1); ++i)
+            {
+                arr[i] = (byte) ((GetHexVal(hex[i << 1]) << 4) + (GetHexVal(hex[(i << 1) + 1])));
+            }
+
+            return arr;
+        }
+
+        private static int GetHexVal(char hex)
+        {
+            int val = hex;
+            return val - (val < 58 ? 48 : 55);
+        }
+
+        public RsaKey RsaJson { get; private set; }
+    }
+}

--- a/CSharpTradeOffers/SteamRequestHandler.cs
+++ b/CSharpTradeOffers/SteamRequestHandler.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Cache;
+using System.Text;
+
+namespace CSharpTradeOffers
+{
+    public class SteamRequestHandler : IRequestHandler<SteamResponse>
+    {
+        public SteamResponse HandleRequest(string url, string method, Dictionary<string, string> data = null,
+            CookieContainer cookies = null, bool xHeaders = true, string referer = "")
+        {
+            bool isGetMethod = (method.ToLower() == "get");
+            string dataString = null;
+
+            if (data != null)
+                dataString = "?" + DictionaryToUrlString(data);
+
+            if (isGetMethod && !string.IsNullOrEmpty(dataString))
+            {
+                url += dataString;
+            }
+
+            var request = WebRequest.Create(url) as HttpWebRequest;
+            if (request != null)
+            {
+                request.Method = method;
+                request.Accept = "application/json, text/javascript;q=0.9, */*;q=0.5";
+                request.ContentType = "application/x-www-form-urlencoded; charset=UTF-8";
+
+                request.UserAgent =
+                    "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36";
+                request.Referer = String.IsNullOrEmpty(referer) ? "http://steamcommunity.com/" : referer;
+                request.Timeout = 50000;
+                request.CachePolicy = new HttpRequestCachePolicy(HttpRequestCacheLevel.Revalidate);
+                request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+
+                if (xHeaders)
+                {
+                    request.Headers.Add("X-Requested-With", "XMLHttpRequest");
+                    request.Headers.Add("X-Prototype-Version", "1.7");
+                }
+                request.CookieContainer = cookies ?? new CookieContainer();
+
+                if (data != null && !isGetMethod)
+                {
+                    //string dataString = DictionaryToURLString(data);
+                    byte[] dataBytes = Encoding.UTF8.GetBytes(DictionaryToUrlString(data));
+                    request.ContentLength = dataBytes.Length;
+
+                    using (var reqStream = request.GetRequestStream())
+                    {
+                        reqStream.Write(dataBytes, 0, dataBytes.Length);
+                    }
+                }
+
+                return new SteamResponse(request.GetResponse() as HttpWebResponse);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Converts a dictionary to URL parameters. Ex: ?param=arg
+        /// </summary>
+        /// <param name="dict">The Dictionary to be converted.</param>
+        /// <returns>A concatenated string of URL arguments.</returns>
+        private static string DictionaryToUrlString(Dictionary<string, string> dict)
+        {
+            string joined = "";
+            foreach (KeyValuePair<string, string> kvp in dict)
+            {
+                if (joined != "")
+                    joined += "&";
+
+                joined += $"{WebUtility.UrlEncode(kvp.Key)}={WebUtility.UrlEncode(kvp.Value)}";
+            }
+            return joined;
+        }
+    }
+}

--- a/CSharpTradeOffers/SteamResponse.cs
+++ b/CSharpTradeOffers/SteamResponse.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.Net;
+
+namespace CSharpTradeOffers
+{
+    public class SteamResponse : IResponse
+    {
+        private readonly HttpWebResponse _httpWebResponse;
+
+        public SteamResponse(HttpWebResponse httpWebResponse)
+        {
+            _httpWebResponse = httpWebResponse;
+        }
+
+        public CookieCollection Cookies => _httpWebResponse.Cookies;
+
+        public Stream GetResponseStream()
+        {
+            return _httpWebResponse.GetResponseStream();
+        }
+
+        public void Dispose()
+        {
+            _httpWebResponse.Dispose();
+        }
+    }
+}

--- a/CSharpTradeOffers/SteamResponse.cs
+++ b/CSharpTradeOffers/SteamResponse.cs
@@ -1,9 +1,8 @@
-using System.IO;
 using System.Net;
 
 namespace CSharpTradeOffers
 {
-    public class SteamResponse : IResponse
+    public sealed class SteamResponse : IResponse
     {
         private readonly HttpWebResponse _httpWebResponse;
 
@@ -14,9 +13,9 @@ namespace CSharpTradeOffers
 
         public CookieCollection Cookies => _httpWebResponse.Cookies;
 
-        public Stream GetResponseStream()
+        public ISteamStream GetResponseStream()
         {
-            return _httpWebResponse.GetResponseStream();
+            return new SteamStream(_httpWebResponse.GetResponseStream());
         }
 
         public void Dispose()

--- a/CSharpTradeOffers/SteamStream.cs
+++ b/CSharpTradeOffers/SteamStream.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+
+namespace CSharpTradeOffers
+{
+    internal sealed class SteamStream : ISteamStream
+    {
+        private readonly Stream _stream;
+
+        public SteamStream(Stream stream)
+        {
+            _stream = stream;
+        }
+
+        public string ReadToEnd()
+        {
+            using (StreamReader streamReader = new StreamReader(_stream))
+            {
+                return streamReader.ReadToEnd();
+            }
+        }
+
+        public Stream GetUnderlyingStream()
+        {
+            // TODO: We don't really want to expose the Stream, as it defeats the point of having this SteamStream facade. 
+            // TODO: (cont.) It will make unit testing harder later on. But at the moment, some classes rely on this.
+            return _stream;
+        }
+    }
+}

--- a/CSharpTradeOffers/Trading/EconServiceHandler.cs
+++ b/CSharpTradeOffers/Trading/EconServiceHandler.cs
@@ -10,6 +10,7 @@ namespace CSharpTradeOffers.Trading
     public class EconServiceHandler
     {
         private readonly string _apiKey;
+        private readonly Web _web = new Web(new SteamRequestHandler());
 
         private const string BaseUrl = "https://api.steampowered.com/IEconService/";
 
@@ -31,7 +32,7 @@ namespace CSharpTradeOffers.Trading
             data.Add("format", "json");
             return
                 JsonConvert.DeserializeObject<TradeOffers>(
-                    WebUtility.UrlDecode(Web.Fetch(url, "GET", data))).Response;
+                    WebUtility.UrlDecode(_web.Fetch(url, "GET", data))).Response;
         }
 
         /// <summary>
@@ -52,7 +53,7 @@ namespace CSharpTradeOffers.Trading
             };
             return
                 JsonConvert.DeserializeObject<CEconTradeOffer>(
-                    WebUtility.UrlDecode(Web.Fetch(url, "GET", data)));
+                    WebUtility.UrlDecode(_web.Fetch(url, "GET", data)));
         }
 
         /// <summary>
@@ -69,7 +70,7 @@ namespace CSharpTradeOffers.Trading
                 {"tradeofferid", tradeofferid.ToString()},
                 {"format", "json"}
             };
-            return Web.Fetch(url, "POST", data);
+            return _web.Fetch(url, "POST", data);
         }
 
         /// <summary>
@@ -86,7 +87,7 @@ namespace CSharpTradeOffers.Trading
                 {"tradeofferid", tradeofferid.ToString()},
                 {"format", "json"}
             };
-            return WebUtility.UrlDecode(Web.Fetch(url, "POST", data));
+            return WebUtility.UrlDecode(_web.Fetch(url, "POST", data));
         }
 
         /// <summary>
@@ -111,7 +112,7 @@ namespace CSharpTradeOffers.Trading
             };
             return
                 JsonConvert.DeserializeObject<Trade>(
-                    WebUtility.UrlDecode(Web.Fetch(string.Format(url, tradeId.TradeId), "POST",
+                    WebUtility.UrlDecode(_web.Fetch(string.Format(url, tradeId.TradeId), "POST",
                         data, container, false, "https://steamcommunity.com/tradeoffer/" + tradeId.TradeId + "/")));
         }
 
@@ -137,7 +138,7 @@ namespace CSharpTradeOffers.Trading
             };
             return
                 JsonConvert.DeserializeObject<Trade>(
-                    WebUtility.UrlDecode(Web.Fetch(string.Format(url, tradeId), "POST",
+                    WebUtility.UrlDecode(_web.Fetch(string.Format(url, tradeId), "POST",
                         data, container, false, "https://steamcommunity.com/tradeoffer/" + tradeId + "/")));
         }
 
@@ -166,7 +167,7 @@ namespace CSharpTradeOffers.Trading
                 {"captcha", ""},
                 {"trade_offer_create_params", "{}"}
             };
-            return JsonConvert.DeserializeObject<SendOfferResponse>(Web.Fetch(url, "POST", data, container, false,
+            return JsonConvert.DeserializeObject<SendOfferResponse>(_web.Fetch(url, "POST", data, container, false,
                 "https://steamcommunity.com/tradeoffer/new/?partner=" +
                 SteamIdOperations.ConvertSteamIdToAccountId(SteamIdOperations.ConvertUlongToSteamId(partnerSid))));
         }
@@ -198,7 +199,7 @@ namespace CSharpTradeOffers.Trading
                 {"trade_offer_create_params", "{}"},
                 {"tradeofferid_countered", tradeofferidCountered.ToString()}
             };
-            return JsonConvert.DeserializeObject<SendOfferResponse>(Web.Fetch(url, "POST", data, container, false,
+            return JsonConvert.DeserializeObject<SendOfferResponse>(_web.Fetch(url, "POST", data, container, false,
                 "https://steamcommunity.com/tradeoffer/" + tradeofferidCountered + "/"));
         }
 
@@ -216,7 +217,7 @@ namespace CSharpTradeOffers.Trading
                 {"time_last_visit", timeLastVisit.ToString()}
             };
             return
-                JsonConvert.DeserializeObject<GetTradeOffersSummaryBaseResponse>(Web.Fetch(url, "GET", data)).Response;
+                JsonConvert.DeserializeObject<GetTradeOffersSummaryBaseResponse>(_web.Fetch(url, "GET", data)).Response;
         }
     }
 }

--- a/CSharpTradeOffers/Trading/Inventory.cs
+++ b/CSharpTradeOffers/Trading/Inventory.cs
@@ -8,6 +8,8 @@ namespace CSharpTradeOffers.Trading
     public class Inventory
     {
         private readonly ulong _steamId;
+        private readonly Web _web = new Web(new SteamRequestHandler());
+        
 
         /// <summary>
         /// Class constructor, automatically initializes inventory.
@@ -46,7 +48,7 @@ namespace CSharpTradeOffers.Trading
         private dynamic RequestInventory(uint appId)
         {
             string url = "https://steamcommunity.com/profiles/" + _steamId + "/inventory/json/" + appId + "/2/";
-            return JsonConvert.DeserializeObject<dynamic>(Web.Fetch(url, "GET", null, null, false));
+            return JsonConvert.DeserializeObject<dynamic>(_web.Fetch(url, "GET", null, null, false));
         }
 
         /// <summary>

--- a/CSharpTradeOffers/Trading/SteamEconomyHandler.cs
+++ b/CSharpTradeOffers/Trading/SteamEconomyHandler.cs
@@ -11,6 +11,7 @@ namespace CSharpTradeOffers.Trading
     {
         private const string BaseUrl = "https://api.steampowered.com/ISteamEconomy/";
         private readonly string _apiKey;
+        private readonly Web _web = new Web(new SteamRequestHandler());
 
         public SteamEconomyHandler(string apiKey)
         {
@@ -41,7 +42,7 @@ namespace CSharpTradeOffers.Trading
                 currentClass++;
             }
 
-            dynamic dynamicinfo = JsonConvert.DeserializeObject<dynamic>(Web.Fetch(url, "GET", data, null, false)).result;
+            dynamic dynamicinfo = JsonConvert.DeserializeObject<dynamic>(_web.Fetch(url, "GET", data, null, false)).result;
 
             Dictionary<string, dynamic> desrDictionary =
                 JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(dynamicinfo.ToString());
@@ -69,7 +70,7 @@ namespace CSharpTradeOffers.Trading
                 {"language", language}
             };
             return
-                JsonConvert.DeserializeObject<GetAssetPricesBaseResponse>(Web.Fetch(url, "GET", data, null, false))
+                JsonConvert.DeserializeObject<GetAssetPricesBaseResponse>(_web.Fetch(url, "GET", data, null, false))
                     .Result;
         }
     }

--- a/CSharpTradeOffers/Web.cs
+++ b/CSharpTradeOffers/Web.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.Net;
-using System.Text;
 using Newtonsoft.Json;
-using System.Net.Cache;
 using System.Threading;
 using System.Collections.Generic;
-using System.Security.Cryptography;
+using CSharpTradeOffers.Json;
 
 namespace CSharpTradeOffers
 {
@@ -15,6 +13,7 @@ namespace CSharpTradeOffers
     /// </summary>
     public class Web
     {
+        private readonly IRequestHandler<IResponse> _requestHandler;
         public const string SteamCommunityDomain = "steamcommunity.com";
 
         public static string SteamLogin { get; private set; }
@@ -29,6 +28,11 @@ namespace CSharpTradeOffers
 
         private static CookieContainer _cookies = new CookieContainer();
 
+        public Web(IRequestHandler<IResponse> requestHandler)
+        {
+            _requestHandler = requestHandler;
+        }
+
         /// <summary>
         /// Fetch calls this method.
         /// </summary>
@@ -39,55 +43,10 @@ namespace CSharpTradeOffers
         /// <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
         /// <param name="referer">Sets the referrer for the request.</param>
         /// <returns>An HttpWebResponse object from the requested URL.</returns>
-        public static HttpWebResponse Request(string url, string method, Dictionary<string, string> data = null,
+        public IResponse Request(string url, string method, Dictionary<string, string> data = null,
             CookieContainer cookies = null, bool xHeaders = true, string referer = "")
         {
-            bool isGetMethod = (method.ToLower() == "get");
-            string dataString = null;
-
-            if (data != null)
-                dataString = "?" + DictionaryToUrlString(data);
-
-            if (isGetMethod && !string.IsNullOrEmpty(dataString))
-            {
-                url += dataString;
-            }
-
-            var request = WebRequest.Create(url) as HttpWebRequest;
-            if (request != null)
-            {
-                request.Method = method;
-                request.Accept = "application/json, text/javascript;q=0.9, */*;q=0.5";
-                request.ContentType = "application/x-www-form-urlencoded; charset=UTF-8";
-
-                request.UserAgent =
-                    "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36";
-                request.Referer = string.IsNullOrEmpty(referer) ? "http://steamcommunity.com/" : referer;
-                request.Timeout = 50000;
-                request.CachePolicy = new HttpRequestCachePolicy(HttpRequestCacheLevel.Revalidate);
-                request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
-
-                if (xHeaders)
-                {
-                    request.Headers.Add("X-Requested-With", "XMLHttpRequest");
-                    request.Headers.Add("X-Prototype-Version", "1.7");
-                }
-                request.CookieContainer = cookies ?? new CookieContainer();
-
-                if (data != null && !isGetMethod)
-                {
-                    //string dataString = DictionaryToURLString(data);
-                    byte[] dataBytes = Encoding.UTF8.GetBytes(DictionaryToUrlString(data));
-                    request.ContentLength = dataBytes.Length;
-
-                    using (var reqStream = request.GetRequestStream())
-                    {
-                        reqStream.Write(dataBytes, 0, dataBytes.Length);
-                    }
-                }
-                return request.GetResponse() as HttpWebResponse;
-            }
-            return null;
+            return _requestHandler.HandleRequest(url, method, data, cookies, xHeaders, referer);
         }
 
         /// <summary>
@@ -100,11 +59,11 @@ namespace CSharpTradeOffers
         /// <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
         /// <param name="referer">Sets the referrer for the request.</param>
         /// <returns>A string from the response stream.</returns>
-        public static string Fetch(string url, string method, Dictionary<string, string> data = null, CookieContainer cookies = null, bool xHeaders = true, string referer = "")
+        public string Fetch(string url, string method, Dictionary<string, string> data = null, CookieContainer cookies = null, bool xHeaders = true, string referer = "")
         {
-            HttpWebResponse response = Request(url, method, data, cookies, xHeaders, referer);
+            IResponse response = Request(url, method, data, cookies, xHeaders, referer);
 
-            using (var sr = new StreamReader(response.GetResponseStream()))
+            using (StreamReader sr = new StreamReader(response.GetResponseStream()))
             {
                 return sr.ReadToEnd();
             }
@@ -120,7 +79,7 @@ namespace CSharpTradeOffers
         /// <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
         /// <param name="referer">Sets the referrer for the request.</param>
         /// <returns>A string from the response stream.</returns>
-        public static string RetryFetch(int retryWait, int retryCount, string url, string method, Dictionary<string, string> data = null,
+        public string RetryFetch(int retryWait, int retryCount, string url, string method, Dictionary<string, string> data = null,
             CookieContainer cookies = null, bool xHeaders = true, string referer = "")
         {
             int attempts = 0;
@@ -155,7 +114,7 @@ namespace CSharpTradeOffers
         /// <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
         /// <param name="referer">Sets the referrer for the request.</param>
         /// <returns>A string from the response stream.</returns>
-        public static Stream RetryFetchStream(int retryWait, int retryCount, string url, string method, Dictionary<string, string> data = null,
+        public Stream RetryFetchStream(int retryWait, int retryCount, string url, string method, Dictionary<string, string> data = null,
             CookieContainer cookies = null, bool xHeaders = true, string referer = "")
         {
             int attempts = 0;
@@ -186,41 +145,26 @@ namespace CSharpTradeOffers
         /// <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
         /// <param name="referer">Sets the referrer for the request.</param>
         /// <returns>The response stream.</returns>
-        public static Stream FetchStream(string url, string method, Dictionary<string, string> data = null, CookieContainer cookies = null, bool xHeaders = true, string referer = "")
+        public Stream FetchStream(string url, string method, Dictionary<string, string> data = null, CookieContainer cookies = null, bool xHeaders = true, string referer = "")
         {
             return Request(url, method, data, cookies, xHeaders, referer).GetResponseStream();
         }
 
         /// <summary>
-        /// Converts a dictionary to URL parameters. Ex: ?param=arg
-        /// </summary>
-        /// <param name="dict">The Dictionary to be converted.</param>
-        /// <returns>A concatenated string of URL arguments.</returns>
-        public static string DictionaryToUrlString(Dictionary<string, string> dict)
-        {
-            string joined = "";
-            foreach (KeyValuePair<string, string> kvp in dict)
-            {
-                if (joined != "")
-                    joined += "&";
-
-                //joined += $"{WebUtility.UrlEncode(kvp.Key)}={WebUtility.UrlEncode(kvp.Value)}";
-                joined += $"{WebUtility.UrlEncode(kvp.Key)}={WebUtility.UrlEncode(kvp.Value)}";
-            }
-            return joined;
-        }
-
-        /// <summary>
         /// Executes the login by using the Steam Website.
         /// </summary> 
-        public static Account DoLogin(string username, string password, string machineAuth = "")
+        public Account DoLogin(string username, string password, string machineAuth = "")
         {
             Thread.Sleep(2000);
-            RsaHelper rsaHelper = new RsaHelper(username, password);
-            string encryptedBase64Password = rsaHelper.EncryptPassword();
-            if(encryptedBase64Password == null) return null;
-            
-            DoLoginResult loginJson = null;
+            RsaHelper rsaHelper = new RsaHelper(password);
+
+            var loginDetails = new Dictionary<string, string> {{"username", username}};
+            string response = Fetch("https://steamcommunity.com/login/getrsakey", "POST", loginDetails);
+
+            string encryptedBase64Password = rsaHelper.EncryptPasswordResponse(response);
+            if (encryptedBase64Password == null) return null;
+
+            LoginResult loginJson = null;
             CookieCollection cookieCollection;
             string steamGuardText = "";
             string steamGuardId = "";
@@ -292,12 +236,12 @@ namespace CSharpTradeOffers
                     cc.Add(new Uri("https://steamcommunity.com/login/dologin/"), machineCookie);
                 }
 
-                using (var webResponse = Request("https://steamcommunity.com/login/dologin/", "POST", data, cc))
+                using (IResponse webResponse = Request("https://steamcommunity.com/login/dologin/", "POST", data, cc))
                 {
                     using (var reader = new StreamReader(webResponse.GetResponseStream()))
                     {
                         var json = reader.ReadToEnd();
-                        loginJson = JsonConvert.DeserializeObject<DoLoginResult>(json);
+                        loginJson = JsonConvert.DeserializeObject<LoginResult>(json);
                         cookieCollection = webResponse.Cookies;
                     }
                 }
@@ -352,7 +296,7 @@ namespace CSharpTradeOffers
             return null;
         }
 
-        public static Account RetryDoLogin(string username, string password, string machineAuth = "",
+        public Account RetryDoLogin(string username, string password, string machineAuth = "",
             int retryLimit = 10, int retryWait = 500)
         {
             int retries = 0;
@@ -374,7 +318,7 @@ namespace CSharpTradeOffers
             return account;
         }
 
-        static void SubmitCookies(CookieContainer cookies)
+        private static void SubmitCookies(CookieContainer cookies)
         {
             var w = WebRequest.Create("https://steamcommunity.com/") as HttpWebRequest;
 
@@ -387,130 +331,6 @@ namespace CSharpTradeOffers
 
                 w.GetResponse().Close();
             }
-        }
-
-        public class RsaHelper
-        {
-            private readonly string _username;
-
-            private readonly string _password;
-
-            public RsaHelper(string username, string password)
-            {
-                _username = username;
-                _password = password;
-            }
-
-            public bool RequestRsaKey()
-            {
-                var data = new Dictionary<string, string> { { "username", _username } };
-                string response = Fetch("https://steamcommunity.com/login/getrsakey", "POST", data);
-                GetRsaKey rsaJson = JsonConvert.DeserializeObject<GetRsaKey>(response);
-                if (!rsaJson.Success) return false;
-                RsaJson = rsaJson;
-                return true;
-            }
-
-            public string EncryptPassword()
-            {
-                if (!RequestRsaKey()) return null;
-
-                //RSA Encryption
-                var rsa = new RSACryptoServiceProvider();
-                var rsaParameters = new RSAParameters
-                {
-                    Exponent = HexToByte(RsaJson.PublicKeyExp),
-                    Modulus = HexToByte(RsaJson.PublicKeyMod)
-                };
-
-
-                rsa.ImportParameters(rsaParameters);
-
-                byte[] bytePassword = Encoding.ASCII.GetBytes(_password);
-                byte[] encodedPassword = rsa.Encrypt(bytePassword, false);
-                return Convert.ToBase64String(encodedPassword);
-            }
-
-            private static byte[] HexToByte(string hex)
-            {
-                if (hex.Length % 2 == 1)
-                    throw new Exception("The binary key cannot have an odd number of digits");
-
-                byte[] arr = new byte[hex.Length >> 1];
-                int l = hex.Length;
-
-                for (int i = 0; i < (l >> 1); ++i)
-                {
-                    arr[i] = (byte)((GetHexVal(hex[i << 1]) << 4) + (GetHexVal(hex[(i << 1) + 1])));
-                }
-
-                return arr;
-            }
-
-            private static int GetHexVal(char hex)
-            {
-                int val = hex;
-                return val - (val < 58 ? 48 : 55);
-            }
-
-            public GetRsaKey RsaJson { get; private set; }
-        }
-
-        // JSON Classes
-
-        public class GetRsaKey
-        {
-            [JsonProperty("success")]
-            public bool Success { get; set; }
-            [JsonProperty("publickey_mod")]
-            public string PublicKeyMod { get; set; }
-            [JsonProperty("publickey_exp")]
-            public string PublicKeyExp { get; set; }
-            [JsonProperty("timestamp")]
-            public string TimeStamp { get; set; }
-        }
-        
-
-        [JsonObject(Title = "RootObject")]
-        public class DoLoginResult
-        {
-            [JsonProperty("success")]
-            public bool Success { get; set; }
-            [JsonProperty("requires_twofactor")]
-            public bool RequiresTwofactor { get; set; }
-            [JsonProperty("message")]
-            public string Message { get; set; }
-            [JsonProperty("captcha_needed")]
-            public bool CaptchaNeeded { get; set; }
-            [JsonProperty("captcha_gid")]
-            public string CaptchaGid { get; set; }
-            [JsonProperty("emailauth_needed")]
-            public bool EmailAuthNeeded { get; set; }
-            [JsonProperty("emaildomain")]
-            public string EmailDomain { get; set; }
-            [JsonProperty("emailsteamid")]
-            public string EmailSteamId { get; set; }
-            [JsonProperty("login_complete")]
-            public bool LoginComplete { get; set; }
-            [JsonProperty("transfer_url")]
-            public string TransferUrl { get; set; }
-            [JsonProperty("transfer_parameters")]
-            public TransferParameters TransferParameters { get; set; }
-        }
-
-        [JsonObject(Title = "Transfer_Parameters")]
-        public class TransferParameters
-        {
-            [JsonProperty("steamid")]
-            public string Steamid { get; set; }
-            [JsonProperty("token")]
-            public string Token { get; set; }
-            [JsonProperty("auth")]
-            public string Auth { get; set; }
-            [JsonProperty("remember_login")]
-            public bool RememberLogin { get; set; }
-            [JsonProperty("token_secure")]
-            public string TokenSecure { get; set; }
         }
     }
 }

--- a/CSharpTradeOffers/bin/Debug/CSharpTradeOffers.XML
+++ b/CSharpTradeOffers/bin/Debug/CSharpTradeOffers.XML
@@ -767,9 +767,15 @@
             </summary>
             <param name="url">The URL to request.</param>
             <param name="method">The method to be used. Ex: POST</param>
-            <param name="data">Dictionary> containing the paramters to be sent in the URL or in the Stream, depending on the method.</param>
+            <param name="data">
+            Dictionary> containing the paramters to be sent in the URL or in the Stream, depending on the
+            method.
+            </param>
             <param name="cookies">A cookiecontainer with cookies to send.</param>
-            <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
+            <param name="xHeaders">
+            Special parameter, should only be used with requests that need "X-Requested-With:
+            XMLHttpRequest" and "X-Prototype-Version: 1.7"
+            </param>
             <param name="referer">Sets the referrer for the request.</param>
             <returns>An HttpWebResponse object from the requested URL.</returns>
         </member>
@@ -781,7 +787,10 @@
             <param name="method">The method to be used. Ex: POST</param>
             <param name="data">Dictionary containing the paramters to be sent in the URL or in the Stream, depending on the method.</param>
             <param name="cookies">A cookiecontainer with cookies to send.</param>
-            <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
+            <param name="xHeaders">
+            Special parameter, should only be used with requests that need "X-Requested-With:
+            XMLHttpRequest" and "X-Prototype-Version: 1.7"
+            </param>
             <param name="referer">Sets the referrer for the request.</param>
             <returns>A string from the response stream.</returns>
         </member>
@@ -793,7 +802,10 @@
             <param name="method">The method to be used. Ex: POST</param>
             <param name="data">Dictionary containing the paramters to be sent in the URL or in the Stream, depending on the method.</param>
             <param name="cookies">A cookiecontainer with cookies to send.</param>
-            <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
+            <param name="xHeaders">
+            Special parameter, should only be used with requests that need "X-Requested-With:
+            XMLHttpRequest" and "X-Prototype-Version: 1.7"
+            </param>
             <param name="referer">Sets the referrer for the request.</param>
             <returns>A string from the response stream.</returns>
         </member>
@@ -805,7 +817,10 @@
             <param name="method">The method to be used. Ex: POST</param>
             <param name="data">Dictionary containing the paramters to be sent in the URL or in the Stream, depending on the method.</param>
             <param name="cookies">A cookiecontainer with cookies to send.</param>
-            <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
+            <param name="xHeaders">
+            Special parameter, should only be used with requests that need "X-Requested-With:
+            XMLHttpRequest" and "X-Prototype-Version: 1.7"
+            </param>
             <param name="referer">Sets the referrer for the request.</param>
             <returns>A string from the response stream.</returns>
         </member>
@@ -817,14 +832,17 @@
             <param name="method">The method to be used. Ex: POST</param>
             <param name="data">Dictionary containing the paramters to be sent in the URL or in the Stream, depending on the method.</param>
             <param name="cookies">A cookiecontainer with cookies to send.</param>
-            <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
+            <param name="xHeaders">
+            Special parameter, should only be used with requests that need "X-Requested-With:
+            XMLHttpRequest" and "X-Prototype-Version: 1.7"
+            </param>
             <param name="referer">Sets the referrer for the request.</param>
             <returns>The response stream.</returns>
         </member>
         <member name="M:CSharpTradeOffers.Web.DoLogin(System.String,System.String,System.String)">
             <summary>
             Executes the login by using the Steam Website.
-            </summary> 
+            </summary>
         </member>
     </members>
 </doc>

--- a/CSharpTradeOffers/bin/Debug/CSharpTradeOffers.XML
+++ b/CSharpTradeOffers/bin/Debug/CSharpTradeOffers.XML
@@ -340,6 +340,13 @@
             </summary>
             <param name="towrite"></param>
         </member>
+        <member name="M:CSharpTradeOffers.SteamRequestHandler.DictionaryToUrlString(System.Collections.Generic.Dictionary{System.String,System.String})">
+            <summary>
+            Converts a dictionary to URL parameters. Ex: ?param=arg
+            </summary>
+            <param name="dict">The Dictionary to be converted.</param>
+            <returns>A concatenated string of URL arguments.</returns>
+        </member>
         <member name="M:CSharpTradeOffers.Trading.CEconAsset.GetMarketHashName(System.String)">
             <param name="apiKey"></param>
             <returns></returns>
@@ -813,13 +820,6 @@
             <param name="xHeaders">Special parameter, should only be used with requests that need "X-Requested-With: XMLHttpRequest" and "X-Prototype-Version: 1.7"</param>
             <param name="referer">Sets the referrer for the request.</param>
             <returns>The response stream.</returns>
-        </member>
-        <member name="M:CSharpTradeOffers.Web.DictionaryToUrlString(System.Collections.Generic.Dictionary{System.String,System.String})">
-            <summary>
-            Converts a dictionary to URL parameters. Ex: ?param=arg
-            </summary>
-            <param name="dict">The Dictionary to be converted.</param>
-            <returns>A concatenated string of URL arguments.</returns>
         </member>
         <member name="M:CSharpTradeOffers.Web.DoLogin(System.String,System.String,System.String)">
             <summary>

--- a/CSharpTradeOffers/bin/Debug/CSharpTradeOffers.XML
+++ b/CSharpTradeOffers/bin/Debug/CSharpTradeOffers.XML
@@ -164,7 +164,7 @@
             <param name="groupName">The name of the group to request information about.</param>
             <returns>A memberList object.</returns>
         </member>
-        <member name="M:CSharpTradeOffers.Community.CommunityHandler.RequestAllMemberLists(System.UInt64,System.Int32,System.Int32)">
+        <member name="M:CSharpTradeOffers.Community.CommunityHandler.RequestAllMemberLists(System.UInt64,System.TimeSpan,System.Int32)">
             <summary>
             Requests group information as well as all pages of users.
             </summary>
@@ -173,7 +173,7 @@
             <param name="retryCount">The number of times to retry before inserting a null MemberList object.</param>
             <returns>A List of the MemberList object.</returns>
         </member>
-        <member name="M:CSharpTradeOffers.Community.CommunityHandler.RequestAllMemberLists(System.String,System.Int32,System.Int32)">
+        <member name="M:CSharpTradeOffers.Community.CommunityHandler.RequestAllMemberLists(System.String,System.TimeSpan,System.Int32)">
             <summary>
             Requests group information as well as the all pages of users.
             </summary>
@@ -785,7 +785,7 @@
             <param name="referer">Sets the referrer for the request.</param>
             <returns>A string from the response stream.</returns>
         </member>
-        <member name="M:CSharpTradeOffers.Web.RetryFetch(System.Int32,System.Int32,System.String,System.String,System.Collections.Generic.Dictionary{System.String,System.String},System.Net.CookieContainer,System.Boolean,System.String)">
+        <member name="M:CSharpTradeOffers.Web.RetryFetch(System.TimeSpan,System.Int32,System.String,System.String,System.Collections.Generic.Dictionary{System.String,System.String},System.Net.CookieContainer,System.Boolean,System.String)">
             <summary>
             A web method to return the response string from the URL.
             </summary>
@@ -797,7 +797,7 @@
             <param name="referer">Sets the referrer for the request.</param>
             <returns>A string from the response stream.</returns>
         </member>
-        <member name="M:CSharpTradeOffers.Web.RetryFetchStream(System.Int32,System.Int32,System.String,System.String,System.Collections.Generic.Dictionary{System.String,System.String},System.Net.CookieContainer,System.Boolean,System.String)">
+        <member name="M:CSharpTradeOffers.Web.RetryFetchStream(System.TimeSpan,System.Int32,System.String,System.String,System.Collections.Generic.Dictionary{System.String,System.String},System.Net.CookieContainer,System.Boolean,System.String)">
             <summary>
             A web method to return the response string from the URL.
             </summary>

--- a/CSharpTradeOffers_Tests/CSharpTradeOffers_Tests.csproj
+++ b/CSharpTradeOffers_Tests/CSharpTradeOffers_Tests.csproj
@@ -35,6 +35,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>
@@ -43,21 +51,21 @@
         <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
+    <Otherwise />
   </Choose>
   <ItemGroup>
     <Compile Include="SteamIDOperations_Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WebTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CSharpTradeOffers\CSharpTradeOffers.csproj">
       <Project>{11ce73a4-5123-46f1-b668-892d6bafcc40}</Project>
       <Name>CSharpTradeOffers</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/CSharpTradeOffers_Tests/SteamIDOperations_Tests.cs
+++ b/CSharpTradeOffers_Tests/SteamIDOperations_Tests.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CSharpTradeOffers;
+using NUnit.Framework;
 
 namespace CSharpTradeOffers_Tests
 {
-    [TestClass]
+    [TestFixture]
     public class SteamIDOperations_Tests
     {
-        [TestMethod]
+        [Test]
         public void ConvertAccountIdtoUInt64_NoFail()
         {
             uint input = 100049908;
@@ -16,7 +16,7 @@ namespace CSharpTradeOffers_Tests
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
+        [Test]
         public void ConvertAccountIdToSteamId_NoFail()
         {
             uint input = 100049908;
@@ -25,7 +25,7 @@ namespace CSharpTradeOffers_Tests
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
+        [Test]
         public void ConvertSteamIdtoULong_NoFail()
         {
             string input = "STEAM_0:0:50024954";
@@ -34,7 +34,7 @@ namespace CSharpTradeOffers_Tests
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
+        [Test]
         [ExpectedException(typeof(IndexOutOfRangeException))]
         public void ConvertSteamIdtoUlong_Exception_IndexOutOfRangeException()
         {
@@ -44,7 +44,7 @@ namespace CSharpTradeOffers_Tests
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
+        [Test]
         public void ConvertUlongToSteamId_NoFail()
         {
             ulong input = 76561198060315636;
@@ -53,7 +53,7 @@ namespace CSharpTradeOffers_Tests
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
+        [Test]
         public void ConvertSteamIdToAccountId_NoFail()
         {
             string input = "STEAM_0:0:50024954"; 
@@ -61,6 +61,5 @@ namespace CSharpTradeOffers_Tests
             uint actual = SteamIdOperations.ConvertSteamIdToAccountId(input);
             Assert.AreEqual(expected, actual);
         }
-        //100049904
     }
 }

--- a/CSharpTradeOffers_Tests/WebTests.cs
+++ b/CSharpTradeOffers_Tests/WebTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Net;
+using CSharpTradeOffers;
+using Moq;
+using NUnit.Framework;
+
+namespace CSharpTradeOffers_Tests
+{
+    [TestFixture]
+    public sealed class WebTests
+    {
+        [SetUp]
+        public void BeforeEachTest()
+        {
+            _mockSteamStream = new Mock<ISteamStream>();
+            _mockSteamStream.Setup(x => x.ReadToEnd()).Returns(SteamStreamResponse);
+
+            _mockResponse = new Mock<IResponse>();
+            _mockResponse.Setup(x => x.GetResponseStream()).Returns(_mockSteamStream.Object);
+
+            _mockRequestHandler = new Mock<IRequestHandler<IResponse>>();
+
+            _mockRequestHandler.Setup(x => x.HandleRequest(Url, Method, null, null, true, "")).Returns(_mockResponse.Object);
+
+            _web = new Web(_mockRequestHandler.Object);
+        }
+
+        private const string Url = "url";
+        private const string Method = "method";
+        private const string SteamStreamResponse = "Response From Steam";
+        private Mock<IRequestHandler<IResponse>> _mockRequestHandler;
+        private Mock<ISteamStream> _mockSteamStream;
+        private Mock<IResponse> _mockResponse;
+        private Web _web;
+
+        [Test]
+        public void FetchStream_ShouldFetchStream()
+        {
+            ISteamStream steamStream = _web.FetchStream(Url, Method);
+
+            Assert.AreEqual(steamStream, _mockSteamStream.Object);
+        }
+
+        [Test]
+        public void RetryFetch_ReturnsNull_WhenExceedingRetryCount()
+        {
+            _mockRequestHandler.Setup(x => x.HandleRequest(Url, Method, null, null, true, "")).Throws<WebException>();
+
+            string response = _web.RetryFetch(new TimeSpan(1), 2, Url, Method);
+            Assert.IsNull(response);
+        }
+
+        [Test]
+        public void RetryFetch_ReturnsSteamStreamResponse_WhenNotExceedingRetryCount()
+        {
+            string response = _web.RetryFetch(new TimeSpan(1), 2, Url, Method);
+            Assert.AreEqual(response, SteamStreamResponse);
+        }
+
+        [Test]
+        public void RetryFetchStream_ReturnsNull_WhenExceedingRetryCount()
+        {
+            _mockRequestHandler.Setup(x => x.HandleRequest(Url, Method, null, null, true, "")).Throws<WebException>();
+
+            ISteamStream steamStream = _web.RetryFetchStream(new TimeSpan(1), 2, Url, Method);
+
+            Assert.IsNull(steamStream);
+        }
+
+        [Test]
+        public void RetryFetchStream_ReturnsSteamStream_WhenNotExceedingRetryCount()
+        {
+            ISteamStream steamStream = _web.RetryFetchStream(new TimeSpan(1), 2, Url, Method);
+
+            Assert.AreEqual(steamStream, _mockSteamStream.Object);
+        }
+
+        [Test]
+        public void WebRequest_Fetch_ReturnsResponseStream()
+        {
+            string responseStream = _web.Fetch(Url, Method);
+
+            Assert.AreEqual(responseStream, SteamStreamResponse);
+        }
+
+        [Test]
+        public void WebRequest_ShouldReturnResponse()
+        {
+            IResponse response = _web.Request(Url, Method);
+
+            Assert.AreEqual(response, _mockResponse.Object);
+        }
+    }
+}

--- a/CSharpTradeOffers_Tests/packages.config
+++ b/CSharpTradeOffers_Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moq" version="4.2.1507.0118" targetFramework="net452" />
+  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
These set of changes add unit tests to Web.

To unit test web, the response functionality was extracted to allow mocking web calls (IRequestHandler). Now we can inject a request implementation into the Web class, and allow mocking in unit tests.